### PR TITLE
Resolve empty string if a template leads to a non existent file

### DIFF
--- a/lib/milieu.js
+++ b/lib/milieu.js
@@ -322,7 +322,9 @@ class Milieu {
             for (let i = 0; i < inlinePathMatches.length; i += 1) {
               const token   = inlinePathMatches[i];
               const path    = token.slice(2, token.length - 1);
-              const fileVal = fs.readFileSync(path);
+              const fileVal = fs.existsSync(path) && fs.statSync(path).isFile()
+                ? fs.readFileSync(path)
+                : '';
 
               ctx[prop] = ctx[prop].replace(token, fileVal);
             }


### PR DESCRIPTION
Allow using file templating with possible non existent files, to avoid implementing the logic to check if the file exist on the config file.

```javascript
const config = milieu('myapp', {
  ca: '$(ca.pem)'
});
```

If the file exists `config.ca` would end up having its content, otherwise just an empty string.