### PR TITLE
process argv according to docs

### DIFF
--- a/lib/milieu.js
+++ b/lib/milieu.js
@@ -289,7 +289,6 @@ class Milieu {
 
   _convertFlagToPath(key) {
     key = key
-      .toLowerCase()
       .replace(/_{2}|-{2}/g, '.')
       .replace(/[_-]([\w])/g, (_, char) => char.toUpperCase());
     return key;


### PR DESCRIPTION
The docs say that `--test.myKey val` becomes `config.test.myKey === 'val'` in the config. This is only true after applying my PR. Without my PR the `--test.myKey val` flag becomes `config.test.mykey === 'val'`.