### PR TITLE
Add default true value for boolean flags

### DIFF
--- a/lib/milieu.js
+++ b/lib/milieu.js
@@ -115,7 +115,7 @@ class Milieu {
       const key = this.__$.argv[i];
       const val = this.__$.argv[i + 1];
       if (key.slice(0, 2) !== '--') { continue; }
-      flags[key.slice(2)] = val;
+      flags[key.slice(2)] = val === undefined ? true : false;
       i += 1;
     }
 


### PR DESCRIPTION
When I set a boolean flag (without value), that flag is created as `undefined`. So when I call `printExplainTable()`, the variable `valueExplaination` (for that flag) is `undefined` too:

```
/Users/ianaya89/Development/bloq/metronome-api/node_modules/milieu/lib/explain-table.js:44
    switch (valueExplaination.src) {
                              ^

TypeError: Cannot read property 'src' of undefined
    at explainTable (/Users/ianaya89/Development/bloq/metronome-api/node_modules/milieu/lib/explain-table.js:44:31)
    at Milieu.printExplainTable (/Users/ianaya89/Development/bloq/metronome-api/node_modules/milieu/lib/milieu.js:87:5)
    at Object.<anonymous> (/Users/ianaya89/Development/bloq/metronome-api/bin/mtn-config:5:8)
    at Module._compile (module.js:635:30)
    at Object.Module._extensions..js (module.js:646:10)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
    at Function.Module.runMain (module.js:676:10)
    at startup (bootstrap_node.js:187:16)
```

This PR should fix the issue, let me know what you think 😀